### PR TITLE
refactor: validation functions

### DIFF
--- a/R/MsBackendSqlDb-functions.R
+++ b/R/MsBackendSqlDb-functions.R
@@ -54,7 +54,7 @@ MsBackendSqlDb <- function() {
                       paste0(cn[!cn %in% names(r)], collapse = ","),
                       " not found"))
 
-    isCorrectType <- mapply(is, object=r[names(req_cols)], class2=req_cols)
+    isCorrectType <- mapply(is, object = r[names(req_cols)], class2 = req_cols)
     if (!all(isCorrectType))
         return(paste0("required column(s) ",
                       paste0(names(req_cols)[!isCorrectType],

--- a/R/MsBackendSqlDb-functions.R
+++ b/R/MsBackendSqlDb-functions.R
@@ -10,40 +10,55 @@ MsBackendSqlDb <- function() {
     new("MsBackendSqlDb")
 }
 
-.valid_db_table_columns <- function(dbcon, dbtable, pkey = "_pkey") {
+#' Test if db table is available
+#'
+#' @param dbcon [`DBIConnection-class`] object
+#' @param dbtable `character(1)`, table name
+#' @author Johannes Rainer, Sebastian Gibb
+#' @noRd
+.valid_db_table_exists <- function(dbcon, dbtable) {
     if (!dbExistsTable(dbcon, dbtable))
-        return(paste0("database table '", dbtable, "' not found"))
-    tmp <- dbGetQuery(dbcon, paste0("select * from ", dbtable, " limit 3"))
-    if (!any(colnames(tmp) == pkey))
-        return(paste0("required column '", pkey ,"' not found"))
-    req_cols <- c(dataStorage = "character",
-                  dataOrigin = "character",
-                  rtime = "numeric",
-                  msLevel = "integer")
-    if (!all(names(req_cols) %in% colnames(tmp)))
-        return(
-            paste0("required column(s) ",
-                   paste0(names(req_cols)[!names(req_cols) %in% colnames(tmp)],
-                          collapse = ", "), " not found"))
-    classes <- vapply(tmp[, names(req_cols)], class, character(1))
-    if (!all(classes == req_cols))
-        return(
-            paste0("required column(s) ",
-                   paste0(names(req_cols)[classes != req_cols], collapse = ", "),
-                   " have the wrong data type"))
-    if (!any(colnames(tmp) == "mz") || !any(colnames(tmp) == "intensity"))
-        return("required columns 'mz' and 'intensity' not found")
-    if (!is(tmp$mz, "blob") || !is(tmp$intensity, "blob"))
-        return("required columns 'mz' and 'intensity' have the wrong data type")
-    NULL
+        paste0("database table '", dbtable, "' not found")
+    else
+        NULL
 }
 
-.valid_db_table_has_columns <- function(dbcon, dbtable, columns) {
-    tmp <- dbGetQuery(dbcon, paste0("select * from ", dbtable, " limit 3"))
-    if (!all(columns %in% colnames(tmp)))
-        return(paste0("columns ",
-                      paste(columns[!columns %in% colnames(tmp)],
-                            collapse = ", "), " not found in ", dbtable))
+#' Test for required columns in db table
+#'
+#' Checks whether all required columns are present and of the correct data type.
+#'
+#' @param dbcon [`DBIConnection-class`] object
+#' @param dbtable `character(1)`, table name
+#' @param columns `character`, user defined columns that have to be present (no
+#' type check available)
+#' @param pkey `character(1)`, name of the PRIMARY KEY column
+#'
+#' @author Johannes Rainer, Sebastian Gibb
+#' @noRd
+.valid_db_table_columns <- function(dbcon, dbtable,
+                                    columns = character(), pkey = "_pkey") {
+    req_cols <- c("integer", # pkey
+                  dataStorage = "character",
+                  dataOrigin = "character",
+                  intensity = "blob",
+                  msLevel = "integer",
+                  mz = "blob",
+                  rtime = "numeric")
+    names(req_cols)[1L] <- pkey
+    cn <- unique(c(names(req_cols), columns))
+
+    r <- dbGetQuery(dbcon, paste0("SELECT * FROM ", dbtable, " LIMIT 0"))
+
+    if (!all(cn %in% names(r)))
+        return(paste0("required column(s) ",
+                      paste0(cn[!cn %in% names(r)], collapse = ","),
+                      " not found"))
+
+    isCorrectType <- mapply(is, object=r[names(req_cols)], class2=req_cols)
+    if (!all(isCorrectType))
+        return(paste0("required column(s) ",
+                      paste0(names(req_cols)[!isCorrectType],
+                             collapse = ","), " has/have the wrong data type"))
     NULL
 }
 

--- a/R/MsBackendSqlDb.R
+++ b/R/MsBackendSqlDb.R
@@ -85,8 +85,8 @@ setClass("MsBackendSqlDb",
                                version = "0.1"))
 
 setValidity("MsBackendSqlDb", function(object) {
-    msg <- .valid_db_table_columns(object@dbcon, object@dbtable)
-    msg <- c(msg, .valid_db_table_has_columns(object@dbcon, object@columns))
+    msg <- .valid_db_table_exists(object@dbcon, object@dbtable)
+    msg <- c(msg, .valid_db_table_columns(object@dbcon, object@columns))
     if (is.null(msg)) TRUE
     else msg
 })

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library("testthat")
+library("MsBackendSql")
+
+test_check("MsBackendSql")

--- a/tests/testthat/test_MsBackendSqlDb-functions.R
+++ b/tests/testthat/test_MsBackendSqlDb-functions.R
@@ -1,0 +1,35 @@
+msdf <- data.frame(
+    pkey = 1L:3L,
+    rtime = c(1.2, 3.4, 5.6),
+    msLevel = c(1L, 2L, 2L),
+    dataStorage = "<db>",
+    dataOrigin = "file.mzML",
+    stringsAsFactors = FALSE
+)
+msdf$mz <- lapply(1:3, serialize, NULL)
+msdf$intensity <- lapply(4:6, serialize, NULL)
+
+con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+on.exit(DBI::dbDisconnect(con))
+
+DBI::dbWriteTable(con, "msdata", msdf)
+
+test_that(".valid_db_table_exists", {
+    expect_null(.valid_db_table_exists(con, "msdata"))
+    expect_match(.valid_db_table_exists(con, "foobar"), "not found")
+})
+
+test_that(".valid_db_table_columns", {
+    expect_null(.valid_db_table_columns(con, "msdata", pkey = "pkey"))
+    expect_match(.valid_db_table_columns(con, "msdata", pkey = "_pkey"),
+                 "required .* not found")
+    expect_match(.valid_db_table_columns(con, "msdata",
+                                         columns = "foo", pkey = "pkey"),
+                 "required .* foo not found")
+
+    msdf2 <- msdf
+    msdf2$msLevel <- as.character(msdf2$msLevel)
+    DBI::dbWriteTable(con, "msdata2", msdf2)
+    expect_match(.valid_db_table_columns(con, "msdata2", pkey = "pkey"),
+                 "wrong data type")
+})


### PR DESCRIPTION
This PR refactors the validation functions:

1. It separates the validity check for the table and the columns (cleaner code design).
2. It tests the required and user defined columns in the same function (avoids on additional SQL call).
3. Use `LIMIT 0` because we don't need any data here (especially for large MS1 spectra the original `LIMIT 3` that would return all *mz* and *intensity* values could be expensive).
4. It uses `is` instead of `class` for type checking because since R 3.6.x `class` could return a `character` longer than 1 (e.g. for `matrix`, while we don't have to deal with matrices here I think `is` is more future proof than `class`)
5. Adds simple unit tests.

Currently it doesn't check the type of the *user defined* columns. Wouldn't that be useful as well?